### PR TITLE
Add timestamp to time anomoly log

### DIFF
--- a/app/codebusters/ciphertesttimed.ts
+++ b/app/codebusters/ciphertesttimed.ts
@@ -11,7 +11,7 @@ import {
     StringMap,
     repeatStr,
     setCharAt,
-    NumberMap,
+    NumberMap, timestampToISOLocalString,
 } from '../common/ciphercommon';
 import { JTButtonItem } from '../common/jtbuttongroup';
 import { TrueTime } from '../common/truetime';
@@ -129,13 +129,14 @@ export class CipherTestTimed extends CipherTest {
      */
     public timeAnomaly(msg: string): void {
         console.log('**Time anomaly reported:' + msg);
+        let localTime = timestampToISOLocalString(Date.now(), true);
         try {
-            this.realtimeSessionNotes.value(this.preInitializationTimeAnomaly + this.realtimeSessionNotes.value() + msg + '|');
+            this.realtimeSessionNotes.value(this.preInitializationTimeAnomaly + this.realtimeSessionNotes.value() + localTime + ' : ' + msg + '|');
             this.preInitializationTimeAnomaly = '';
         } catch (e) {
             // Initially, realtime might not be ready.
             this.preInitializationTimeAnomaly += ('Realtime not ready? ' +
-                e.toString() + ' **MSG: ' + msg + '** |');
+                e.toString() + localTime + ' : **MSG: ' + msg + '** |');
             // no fail.
         }
     }


### PR DESCRIPTION
Added the "current" time to when a time anomaly message is logged to user notes.
See sample.
![image](https://user-images.githubusercontent.com/7691169/117086993-397b3f00-ad1c-11eb-9480-591a212c2731.png)
