### PR TITLE
Fixed issue #589 cryptanalysis not displaying keyword length

### DIFF
--- a/app/codebusters/ciphernihilistsubstitutionencoder.ts
+++ b/app/codebusters/ciphernihilistsubstitutionencoder.ts
@@ -2131,6 +2131,10 @@ export class CipherNihilistSubstitutionEncoder extends CipherEncoder {
             const polybiusKey = this.genMonoText(this.cleanPolyKey);
             operationtext2 += ` with a keyword of ${keyword} and polybius key of ${polybiusKey}`;
         }
+        else {
+            const keyword = this.cleanKeyword;
+            operationtext2 += ` with a keyword length of ${keyword.length}`;
+        }
         return super.addQuestionOptions(qOptions, langtext, hinttext, fixedName, operationtext, operationtext2, cipherAorAn);
 
 


### PR DESCRIPTION
The Nihilist Cryptanalysis cipher suggested question text now includes the keyword length.