### PR TITLE
Update TestGuidance.html

### DIFF
--- a/app/codebusters/pages/TestGuidance.html
+++ b/app/codebusters/pages/TestGuidance.html
@@ -48,7 +48,7 @@
             <div id="Timed">
                 <h2 class="ol">
                     <div class="qusec"></div>
-                    <div class="quseb"></div>Timed question B,C{3.h}
+                    <div class="quseb"></div>Timed Question
                 </h2>
                 <p>This should be a random Aristocrat with no errors and without a hint (see <a
                         href="#Aristocrat">Aristocrats/Patristocrats</a>). Usually Medium difficulty is appropriate, as
@@ -60,7 +60,7 @@
             <div id="Atbash">
                 <h2 class="ol">
                     <div class="quseb"></div>
-                    <div class="qusea"></div>Atbash Cipher A{9.c.ii}, B{3.e.ix}
+                    <div class="qusea"></div>Atbash Cipher
                 </h2>
                 <p>The Atbash is one of the easiest Ciphers for students to encode or decode because the alphabet
                     is fixed. The letter <b>v</b> will always stand for the letter
@@ -97,7 +97,7 @@
             <div id="Caesar">
                 <h2 class="ol">
                     <div class="quseb"></div>
-                    <div class="qusea"></div>Caesar Cipher A{9.c.iii}, B{3.e.x}
+                    <div class="qusea"></div>Caesar Cipher
                 </h2>
                 <p>The Caesar Cipher is a fairly simple cipher where once you know a single letter
                     mapping, the remainder of the problem is a simple transposition. There should be no more than one or
@@ -138,7 +138,7 @@
                 <h2 class="ol">
                     <div class="qusec"></div>
                     <div class="quseb"></div>
-                    <div class="qusea"></div>Aristocrats/Patristocrats A{9.c.i}, B,C{3.e.i}
+                    <div class="qusea"></div>Aristocrats/Patristocrats
                 </h2>
                 <p>These will take up the bulk of the questions. It is helpful to search for a
                     variety of quotes and phrases to use in order to pick the ones which best meet your needs. A good
@@ -262,11 +262,11 @@
                 </p>
             </div>
             <div id="Aristocrat_Hint">
-                <h3 class="ol">
+                <h2 class="ol">
                     <div class="qusec"></div>
                     <div class="quseb"></div>
-                    <div class="qusea"></div>Aristocrat with a hint B,C{3.e.i}
-                </h3>
+                    <div class="qusea"></div>Aristocrat with a hint
+                </h2>
                 <span class="ht">Points:</span>
                 <p class="in">A standard Aristocrat with a hint will be about 200
                     points. See the <a href="#Aristocrat_Points">General
@@ -287,11 +287,11 @@
                 </p>
             </div>
             <div id="Aristocrat_Nohint">
-                <h3 class="ol">
+                <h2 class="ol">
                     <div class="qusec"></div>
                     <div class="quseb"></div>
-                    <div class="qusea"></div>Aristocrat without a hint B,C{3.e.i}
-                </h3>
+                    <div class="qusea"></div>Aristocrat without a hint
+                </h2>
                 <span class="ht">Points:</span>
                 <p class="in">A standard Aristocrat without a hint will be between 250 and 350 points. See the <a
                         href="#Aristocrat_Points">General
@@ -313,9 +313,10 @@
                     as an Aristocrat Cipher. What does it say?</p>
             </div>
             <div id="Aristocrat_Errors_Hint">
-                <h3 class="ol">
-                    Aristocrat with spelling/grammar errors and a hint {not currently used}
-                </h3>
+                <h2 class="ol">
+                    <div class="qusen"></div>
+                    Aristocrat with spelling/grammar errors and a hint
+                </h2>
                 <p class="c12">These can be a lot of fun to generate and can be something that the students relate to.
                     In general the thought process here is something that their phone mistyped when texting using voice.
                     Generating these takes a couple of tries to get something that works out well. It is best to
@@ -367,10 +368,10 @@
                     twice. What was the final result?</p>
             </div>
             <div id="Aristocrat_Errors">
-                <h3 class="ol">
-                    Aristocrat with spelling/grammar
-                    errors with no hint {not currently used}
-                </h3>
+                <h2 class="ol">
+                    <div class="qusen"></div>
+                    Aristocrat with spelling/grammar errors with no hint
+                </h2>
                 <p>Approach these exactly the same as <a href="#Aristocrat_Errors_Hint">Aristocrat
                         with spelling/grammar errors and a hint</a> except that you
                     don't provide a hint. This is one of the hardest questions that can be found on the test.
@@ -397,9 +398,9 @@
                     result?</p>
             </div>
             <div id="Aristocrat_Keyword">
-                <h3 class="ol">
-                    <div class="qusec"></div>Aristocrat K1-K3 Keyword Recovery C{3.e.ii}
-                </h3>
+                <h2 class="ol">
+                    <div class="qusec"></div>Aristocrat K1-K3 Keyword Recovery
+                </h2>
 
                 <p>Recovering a keyword/phrase from an Aristocrat first requires competitors to decode the Aristocrat,
                     so all of the guidance in the
@@ -486,10 +487,10 @@
                 </p>
             </div>
             <div id="Patristocrat">
-                <h3 class="ol">
+                <h2 class="ol">
                     <div class="qusec"></div>
-                    <div class="quseb"></div>Patristocrats with a hint B,C{3.e.i.(2)}
-                </h3>
+                    <div class="quseb"></div>Patristocrats with a hint
+                </h2>
                 <p>Patristocrats should always be encoded with a K1 or K2 alphabet in order to keep
                     them from being too difficult. It is also good to pick phrases with a very low <em>Chi-Square
                         Value</em> to
@@ -518,12 +519,11 @@
                     appears four times in the original text. What did they say?</p>
             </div>
             <div id="Patristocrat_Nohint">
-                <h3 class="ol">
+                <h2 class="ol">
                     <div class="qusec"></div>
                     <div class="quseb"></div>
-                    <div class="qusea"></div>Patristocrats with no hint
-                    B,C{3.e.i.(2)}
-                </h3>
+                    Patristocrats with no hint
+                </h2>
                 <p>Patristocrats with no hint must be encoded with a K1 or K2 alphabet in order to keep
                     them from being too difficult. It is also good to pick phrases with a very low <em>Chi-Square
                         Value</em> to
@@ -547,134 +547,94 @@
                     encoded as
                     a Patristocrat using a K2 alphabet. What did they say?</p>
             </div>
-            <div id="Affinedecode">
+            <div id="Xenocrypt">
                 <h2 class="ol">
-                    <span id="Affine"></span>
-                    <div class="quseb"></div>Affine Cipher decrypt B{3.e.xi}
+                    <div class="qusec"></div>
+                    <div class="quseb"></div>
+                    <div>Spanish Xenocrypt</div>
                 </h2>
-                <p>There should be a single one of these on the test. It should use a phrase about 25
-                    characters long that doesn't have too many occurrences of the letter <span class="fq">A</span> in
-                    it, preferably with as large a variety of letters as possible&hellip; (e.g. <span class="fq">The
-                        quick brown fox jumps over the lazy dog</span> isn't actually bad). </p>
-                <p>Pick a value for <em>a</em> which is coprime with 26
-                    (1,3,5,7,9,11,15,17,19,21,23 or 25). The actual value doesn't matter, but larger ones tend to
-                    be slightly harder. If you are generating tests for multiple regions, pick numbers that are near
-                    each other. I.e. 7, 9 and 11 would be good to have as equivalent <em>a</em> values.</p>
-                <p>Pick a value for <em>b</em> between 1 and 25 inclusive.
-                    Unlike <em>a</em> where the larger values become slightly
-                    harder, the value of <em>b</em> can truly be any number
-                    and be the same level of difficulty. There is an accompanying YouTube video demonstrating how to
-                    create an Affine Cipher Decrypt problem in the YouTube video linked <a class="ytvideo"
-                        href="https://www.youtube.com/watch?v=_eV6ruYNexY">here</a>.</p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">There is very little variability in the
-                    difficulty other than the length of the string. Larger values of <em>a</em> are
-                    only slightly harder while the value of <em>b</em> has no real
-                    impact on the difficulty.</p>
-                <span class="ht">Points:</span>
-                <p class="in">100.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in">The question should state to use the Affine Cipher and
-                    give the values of <em>a</em> and
-                    <em>b</em> for them to use (note that <em>a</em> and
-                    <em>b</em> are italicized).
-                    For example:
+                <p>These ciphers should always be encoded with a K1 or K2 alphabet.</p>
+                <p>Pick a Spanish phrase which primarily consists of words which a second-year Spanish class would
+                    cover. Phrases which have both <span class="fq">la</span> and <span class="fq">las</span> present
+                    are good choices as well as phrases which contain <span class="fq">y</span> or cognates
+                    (Spanish words which are substantially like their English equivalent words such as ciencia,
+                    composici&oacute;n and b&aacute;sico) are also good. For a good source see <a
+                        href="https://www.realfastspanish.com/vocabulary/spanish-cognates">https://www.realfastspanish.com/vocabulary/spanish-cognates</a>.<span
+                        class="c1"> Although it isn't strictly necessary, try to avoid phrases which depend on
+                        accented
+                        characters. As with the approach for the English Aristocrats, pay attention to the
+                        frequency of
+                        letters. The tool automatically calculates the <em>Chi-Square Value</em> to verify the match:
                 </p>
-                <p class="ex callout small secondary ">Decrypt the following cipher text which was encoded using
-                    the Affine Cipher with a=<em>5</em> and b=<em>9</em>.</p>
-            </div>
-            <div id="Affineencode">
-                <h3 class="ol">
-                    Affine Cipher encrypt {not currently used}
-            </div>
-            </h3>
-            <p>There should be at most a single one of these on the test. It should use a phrase about 25
-                characters long that doesn't have too many occurrences of the letter <span class="fq">A</span> in
-                it, preferably with as large a variety of letters as possible&hellip; (e.g. <span class="fq">The
-                    quick brown fox jumps over the lazy dog</span> isn't actually bad). </p>
-            <p>Pick a value for <em>a</em> which is coprime with 26
-                (1,3,5,7,9,11,15,17,19,21,23 or 25). The actual value doesn't matter, but larger ones tend to
-                be slightly harder. If you are generating tests for multiple regions, pick numbers that are near
-                each other. I.e. 7, 9 and 11 would be good to have as equivalent <em>a</em> values.</p>
-            <p>Pick a value for <em>b</em> between 1 and 25 inclusive.
-                Unlike <em>a</em> where the larger values become slightly
-                harder, the value of <em>b</em> can truly be any number
-                and be the same level of difficulty.</p>
-            <span class="ht">Setting Difficulty:</span>
-            <p class="in">There is very little variability in the
-                difficulty other than the length of the string. Larger values of <em>a</em> are
-                only slightly harder while the value of <em>b</em> has no real
-                impact on the difficulty.</p>
-            <span class="ht">Points:</span>
-            <p class="in">100.</p>
-            <span class="ht">Question Text:</span>
-            <p class="in">The question should state to use the Affine Cipher and
-                include the phrase to encode along with the values of <em>a</em> and
-                <em>b</em> for them to use (note that <em>a</em> and
-                <em>b</em> are italicized).
-                For example:
-            </p>
-            <p class="ex callout small secondary ">Encrypt the common phrase <span class="fq">The quick brown fox
-                    jumps over
-                    the
-                    lazy dog</span> using
-                the Affine Cipher with a=5 and b=9.</p>
-            </div>
-            <div id="Vigenere">
-                <h2 class="ol">
-                    <div class="qusea"></div>Vigen&egrave;re Cipher encrypt/decrypt A{9.c.iv}
-                </h2>
-                <p>If the rules allow the Vigen&egrave;re Cipher on a Division B/C test in a given year, there can be
-                    one of each
-                    Encrypt and Decrypt on the test. Division A allows only decryption. There are no restrictions on
-                    the phrase, although try to avoid a phrase with a lot of a's in it. I.e. <span class="fq">An
-                        amazing aardvark allows all answers</span> would be a poor choice because the letter
-                    a is trivial to encode. As this question is nominally worth two points per letter, a 50 letter
-                    phrase
-                    is ideal. </p>
-                <p>Additionally there needs to be a <span class="ctl">Key</span> to encode it
-                    with. It should be 5 or 6 characters with no repeating letters and avoid the letter <em>a</em> as
-                    it causes a letter to map to itself. By setting the <span class="ctl">Block Size</span> to the same
-                    as the
-                    length of the <span class="ctl">Key</span>,
-                    the problem is much easier than with the default <span class="ctl">Block Size</span> of 0
-                    that keeps the original spacing. Setting the <span class="ctl">Block Size</span> to a
-                    size other than the length of the <span class="ctl">Key</span> increases the difficulty
-                    somewhat. There is a YouTube video demonstrating the creation of a Vigen&egrave;re Cipher <a
-                        class="ytvideo" href="https://www.youtube.com/watch?v=IAOOjpn53gs">here</a>.</p>
-                <p>Note that for the Regional/Invitational events, the <span class="ctl">Key</span> must
-                    be given as part of the question.</p>
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>E</td>
+                            <td>A</td>
+                            <td>O</td>
+                            <td>SNR</td>
+                            <td>IL</td>
+                            <td>DTUC</td>
+                            <td>MP</td>
+                            <td>BHQ</td>
+                            <td>YVG&Oacute;&Iacute;</td>
+                            <td>FJZ&Aacute;&Eacute;&Ntilde;X&Uacute;KW&Uuml;</td>
+                        </tr>
+                        <tr>
+                            <td>13%</p>
+                            </td>
+                            <td>12%</p>
+                            </td>
+                            <td>8%</p>
+                            </td>
+                            <td>7%</p>
+                            </td>
+                            <td>6%</p>
+                            </td>
+                            <td>5%</p>
+                            </td>
+                            <td>3%</p>
+                            </td>
+                            <td>2%</p>
+                            </td>
+                            <td>1%</p>
+                            </td>
+                            <td>-</p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p class="c36">If the encoded string uses both <span class="fq">N</span> and <span
+                        class="fq">&Ntilde;</span>,
+                    it is best to re-encode until you don't get them both to avoid
+                    confusion on the part of the teams. Although it is possible to get an encoding that doesn't use
+                    <span class="fq">&Ntilde;</span> at all, it is perfectly fine to generate a question which
+                    has one. Having both both <span class="fq">N</span> and <span class="fq">&Ntilde;</span>, though,
+                    increases the difficulty of the problem.
+                </p>
                 <span class="ht">Setting Difficulty:</span>
-                <p class="in">The <span class="ctl">Block Size</span> is the major
-                    contributor to the difficulty followed by the length of the phrase.</p>
+                <p class="in">The presence of cognates greatly
+                    reduces the difficulty. It is also expected that a K1 alphabet with an English key should be used.
+                    A K2 alphabet can be used, but it doesn't reduce the difficulty as much. In Division B, only a K1
+                    alphabet can be used. In Division C, you might expect to find one of each.</p>
                 <span class="ht">Points:</span>
-                <p class="in">100 for a <span class="ctl">Decode</span> (approximately 2 points per letter), 120
-                    for an Encode. If the <span class="ctl">Block Size</span> is the same as the <span
-                        class="ctl">Key</span>
-                    length
-                    subtract 20 points. If the <span class="ctl">Block Size</span> is
-                    non-zero and different from the <span class="ctl">Key</span> length, add 25
-                    points.</p>
+                <p class="in">600-700.</p>
                 <span class="ht">Question Text:</span>
-                <p class="in"> The question should indicate that the
-                    Vigen&egrave;re Cipher is being used (don't forget the accented &egrave;), whether they are to
-                    Encode
-                    or <span class="ctl">Decode</span> and the Key to use for it. It is generally nice to give the
-                    origin of the
-                    phrase if it is
-                    known. For example:</p>
-                <p class="ex callout small secondary">A phrase by <em>&lt;person&gt;</em> has been encoded using the
-                    Vigen&egrave;re cipher
-                    with a code word
-                    of <span class="fq">SLEPT</span>. What does it say?</p>
-                <p class="ex callout small secondary">Using a keyword of <span class="fq">HORSE</span>, encode this
-                    famous quote by <em>&lt;person&gt;</em> using the Vigen&egrave;re cipher.</p>
+                <p class="in"> The question should clearly indicate that it
+                    is a Spanish Xenocrypt and provide the source of the phrase (if known). It should also indicate the
+                    use of a K1 (or K2) alphabet with an English keyword. For example:</p>
+                <p class="ex callout small secondary ">Solve this Xenocrypt which is a translation of a quote by
+                    <em>&lt;person&gt;</em>
+                    into
+                    Spanish and has been encoded with a K1 alphabet using an English keyword.
+                </p>
             </div>
+
             <div id="Porta">
                 <h2 class="ol">
                     <div class="qusec"></div>
                     <div class="quseb"></div>
-                    <div class="qusea"></div>Porta Cipher encrypt/decrypt B{3.e.vi}, C{3.e.vii}
+                    Porta Cipher encrypt/decrypt
                 </h2>
                 <p>Depending on the rules for a given year, there can be one or two decrypts on the test.
                     (Note that encrypts are not allowed by the current rules.) There are no restrictions
@@ -720,11 +680,61 @@
                 <p class="ex callout small secondary">Using a keyword of <span class="fq">HORSE</span>, encode this
                     famous quote by <em>&lt;person&gt;</em> using the Porta cipher.</p>
             </div>
+            <div id="Vigenere">
+                <h2 class="ol">
+                    <div class="qusea"></div>Vigen&egrave;re Cipher encrypt/decrypt
+                </h2>
+                <p>If the rules allow the Vigen&egrave;re Cipher on a Division B/C test in a given year, there can be
+                    a couple of decryption questions. Division A allows only decryption. There are no restrictions on
+                    the phrase, although try to avoid a phrase with a lot of a's in it. I.e. <span class="fq">An
+                        amazing aardvark allows all answers</span> would be a poor choice because the letter
+                    a is trivial to encode. As this question is nominally worth two points per letter, a 50 letter
+                    phrase
+                    is ideal. </p>
+                <p>Additionally there needs to be a <span class="ctl">Key</span> to encode it
+                    with. It should be 5 or 6 characters with no repeating letters and avoid the letter <em>a</em> as
+                    it causes a letter to map to itself. By setting the <span class="ctl">Block Size</span> to the same
+                    as the
+                    length of the <span class="ctl">Key</span>,
+                    the problem is much easier than with the default <span class="ctl">Block Size</span> of 0
+                    that keeps the original spacing. Setting the <span class="ctl">Block Size</span> to a
+                    size other than the length of the <span class="ctl">Key</span> increases the difficulty
+                    somewhat. There is a YouTube video demonstrating the creation of a Vigen&egrave;re Cipher <a
+                        class="ytvideo" href="https://www.youtube.com/watch?v=IAOOjpn53gs">here</a>.</p>
+                <p>Note that for the Regional/Invitational events, the <span class="ctl">Key</span> must
+                    be given as part of the question.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The <span class="ctl">Block Size</span> is the major
+                    contributor to the difficulty followed by the length of the phrase.</p>
+                <span class="ht">Points:</span>
+                <p class="in">100 for a <span class="ctl">Decode</span> (approximately 2 points per letter), 120
+                    for an Encode. If the <span class="ctl">Block Size</span> is the same as the <span
+                        class="ctl">Key</span>
+                    length
+                    subtract 20 points. If the <span class="ctl">Block Size</span> is
+                    non-zero and different from the <span class="ctl">Key</span> length, add 25
+                    points.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should indicate that the
+                    Vigen&egrave;re Cipher is being used (don't forget the accented &egrave;), whether they are to
+                    Encode
+                    or <span class="ctl">Decode</span> and the Key to use for it. It is generally nice to give the
+                    origin of the
+                    phrase if it is
+                    known. For example:</p>
+                <p class="ex callout small secondary">A phrase by <em>&lt;person&gt;</em> has been encoded using the
+                    Vigen&egrave;re cipher
+                    with a code word
+                    of <span class="fq">SLEPT</span>. What does it say?</p>
+                <p class="ex callout small secondary">Using a keyword of <span class="fq">HORSE</span>, encode this
+                    famous quote by <em>&lt;person&gt;</em> using the Vigen&egrave;re cipher.</p>
+            </div>
+
             <div id="Nihilist">
                 <h2 class="ol">
                     <div class="qusec"></div>
                     <div class="quseb"></div>
-                    <div>Nihilist cipher B{3.e.viii}, C{3.e.ix}</div>
+                    <div>Nihilist cipher</div>
                 </h2>
                 <p>The Nihilist cipher is a substitution cipher. It uses two keywords, the polybius key and normal
                     keyword, to encode the plaintext.
@@ -756,7 +766,7 @@
                 <h2 class="ol">
                     <div class="qusecs"></div>
                     <div class="qusebs"></div>
-                    <div>Nihilist cipher (cryptanalysis) B,C{3.f.v}</div>
+                    <div>Nihilist cipher (cryptanalysis)</div>
                 </h2>
                 <p>The Nihilist cipher is a substitution cipher. It uses two keywords to encode the plaintext.
                     The first is used to construction a Polybius Square which is used to map all of the
@@ -808,7 +818,7 @@
                 <h2 class="ol">
                     <div class="qusec"></div>
                     <div class="quseb"></div>
-                    <div>Checkerboard cipher B{3.e.xii}, C{3.e.xi}</div>
+                    <div>Checkerboard cipher</div>
                 </h2>
                 <p>The Checkerboard cipher is a substitution cipher. It uses three keywords: the polybius key, a row
                     keyword, and a column keyword, to encode the plaintext.
@@ -857,7 +867,7 @@
                 <h2 class="ol">
                     <div class="qusecs"></div>
                     <div class="qusebs"></div>
-                    <div>Checkerboard cipher (cryptanalysis) B{3.f.vi},C{3.f.vii}</div>
+                    <div>Checkerboard cipher (cryptanalysis)</div>
                 </h2>
                 <p>The Checkerboard cipher is a substitution cipher. It uses three keywords to encode the plaintext.
                     The first is used to construct a Polybius Square which is used to create a 5x5 array of all of the
@@ -903,13 +913,113 @@
                     (<span class="fq">YN OT RT RT LN</span>) decode to be <span class="fq">HAPPY</span>.
                 </p>
             </div>
+            <div id="Homophonic">
+                <h2 class="ol">
+                    <div class="qusec"></div>
+                    <div class="quseb"></div>
+                    <div>Homophonic Cipher cryptanalysis</div>
+                </h2>
+                <p>The Homophonic cipher is a monoalphabetic substitution cipher. It uses one keyword (with four unique
+                    letters) to map each letter of the alphabet onto one of four values. The first letter of the keyword
+                    is mapped to the number 1, and the numbers wrap around the alphabet: with I/J sharing a value, the
+                    numbers 1-25 are assigned to the letters. The second letter of the keyword is mapped to 26; the
+                    third is mapped to 51; and the fourth is mapped to 76. Each time a letter is encoded in ciphertext,
+                    one of the four corresponding values is chosen to represent it. In a cryptanalysis problem, be sure
+                    to carefully follow the rules as to how many of the alphabets must be revealed by the crib that is
+                    selected, but in general the idea is that a partial decryption (a "crib" mapping of ciphertext to
+                    plaintext) is provided to competitors.
+                    There should be no more than 2 Homophonic cryptanalysis problems on a test.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in"> A block size of 0 may provide clues to the encoded words, so reduces difficulty
+                    (dramatically, especially if there are single-letter words that would reveal an alphabet). For
+                    this reason, it
+                    is recommended to use a fixed block size (5 is standard, but any value is fine).
+                    A rarer keyword or one with a more unusual letter pattern would make this problem more difficuilt.
+                    Note that the
+                    expectation is that competitors should be
+                    able to recover the keyword by anagramming, so it would be best practice to select a recognizable
+                    keyword. In addition, the difficulty is affected to some degree by
+                    the choice of plaintext: a plaintext with a lower chi-square value containing more common words
+                    would be easier for competitors to solve. Lastly, the best way to evaluate the solvability of this
+                    cipher will be to look at the Auto-Solver's initial work, and see whether it appears to give
+                    competitors a solid place to start working from; and then look at its end state and see if it is
+                    able to completely decrypt the ciphertext. Does it manage to completely solve the cipher? How many
+                    attempts does it have to make? When it begins its work by filling in the provided plaintext, does it
+                    fill in enough pieces of one or more words that competitors can make educated guesses as to other
+                    letters?</p>
+                <span class="ht">Points:</span>
+                <p class="in"> 250-350. A straightforward one where the provided crib gives competitors a solid place to
+                    make educated guesses as to one or more words would be on the lower end; the points would raise if
+                    the crib given only shows competitors plaintext letters that are scattered about and requires them
+                    to make multiple attempts in guessing some of the alphabets.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in">For cryptanalysis, the question text should include a hint of plaintext and the
+                    location of that plaintext.</p>
+                <p class="ex callout small secondary">A phrase by <em>&lt;person&gt;</em> was encoded
+                    using a Homophonic Cipher. The 8th through 12th cipher units
+                    <span class="fq">(62 34 15 77 16)</span> decode to be <span class="fq">PIZZA</span>. What
+                    does it say?
+                </p>
+            </div>
+            <div id="Homophonic_Decode">
+                <h2 class="ol">
+                    <div class="qusecs"></div>
+                    <div class="qusebs"></div>
+                    <div>Homophonic cipher (decode)</div>
+                </h2>
+                <p>The Homophonic cipher, described above, uses a four-letter keyword to map each letter of the alphabet
+                    to four potential numeric values. For a Homophonic decode, no mapping of ciphertext to plaintext is
+                    given. Instead, a number of letters in the keyword are provided in accordance with the rules for a
+                    given division. This typically means that competitors need to think about the most likely positions
+                    where the given letters can appear in a four-letter word, and make and test hypotheses in order to
+                    determine where in the keyword those letters appear, and what the rest of the keyword is then likely
+                    to be.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">In addition to the <a href="#Homophonic">notes above</a>,
+                    a decode using a partial set of keyword letters makes Homophonic ciphers significantly more
+                    difficult due to the iteration and
+                    deduction
+                    required to solve it.
+                    One factor for difficulty is the
+                    Block Size. A Block Size of 0 will make these easier to solve, while a Block Size that is nonzero
+                    will make these more difficult. Another factor for difficulty
+                    is the choice of keyword letters that are provided. For example, a keyword that contains Q is then
+                    likely to also contain U right after it; an E is more likely to appear word-final than word-initial,
+                    and so on.
+                    A third factor for difficulty is whether the letter pattern in the keyword is unusual.
+                    Lastly, it's always helpful to look at the AutoSolver's work and see how it might show the amount of
+                    trial and error a human competitor might have to do to solve the cipher.</p>
+                <span class="ht">Points:</span>
+                <p class="in">300-400. It begins with a similar base to the Homophonic above, in the 200ish range,
+                    and
+                    then bonuses are given for Decode, and then from there there are bonuses based on the work the
+                    AutoSolver is able to complete. The point value given is less if the position of the letters in the
+                    keyword is provided, and greater if they are provided without their accompanying positions.
+                </p>
+                <span class="ht">Question Text:</span>
+                <p class="in">For a decode, the question text can provide either the position of the provided letters in
+                    the Keyword, or just the letters themselves without revealing their positions. Again, ensure that
+                    you are providing the number of letters as appropriate for the rules in a given Division. </p>
+                <p class="ex callout small secondary">
+                    The following quote by <em>&lt;person&gt;</em> has been encoded with the Homophonic
+                    Cipher. You are told that the keyword contains the following letters in the given positions: <span
+                        class="fq">_OL_</span>.</p>
+                <p class="ex callout small secondary">
+                    <em>&lt;Person&gt;</em> has been known to say the following phrase. It has been encoded using the
+                    Homophonic
+                    Cipher. You are told that the keyword contains the following letters: <span class="fq">C,O</span>.
+                </p>
+            </div>
+
             <div id="Baconian">
                 <h2 class="ol">
                     <div class="qusec"></div>
-                    <div class="quseb"></div>Baconian cipher B{3.e.ii}, C{3.e.iii}
+                    <div class="quseb"></div>
+                    <div class="qusea"></div>
+                    <div>Baconian cipher</div>
                 </h2>
                 <p>This is where the test writer can have a lot of fun. The phrase should be approximately
-                    35-60 characters long and ideally should be one for which the ending can't necessarily be guessed
+                    20-35 characters long and ideally should be one for which the ending can't necessarily be guessed
                     once they have decoded the first half; it is important to make sure that they have
                     to work the entire problem. There is little impact on the difficulty.</p>
                 <p>With the <span class="ctl">Words</span> Baconian cipher which is
@@ -1000,92 +1110,11 @@
                     recognized it
                     as a prankster who scratched it on the wall using the Baconian alphabet. What does it say?</p>
             </div>
-            <div id="Xenocrypt">
-                <h2 class="ol">
-                    <div class="qusec"></div>
-                    <div class="quseb"></div>Spanish Xenocrypt B{3.e.iii}, C{3.e.iv}
-                </h2>
-                <p>These ciphers should always be encoded with a K1 or K2 alphabet.</p>
-                <p>Pick a Spanish phrase which primarily consists of words which a second-year Spanish class would
-                    cover. Phrases which have both <span class="fq">la</span> and <span class="fq">las</span> present
-                    are good choices as well as phrases which contain <span class="fq">y</span> or cognates
-                    (Spanish words which are substantially like their English equivalent words such as ciencia,
-                    composici&oacute;n and b&aacute;sico) are also good. For a good source see <a
-                        href="https://www.realfastspanish.com/vocabulary/spanish-cognates">https://www.realfastspanish.com/vocabulary/spanish-cognates</a>.<span
-                        class="c1"> Although it isn't strictly necessary, try to avoid phrases which depend on
-                        accented
-                        characters. As with the approach for the English Aristocrats, pay attention to the
-                        frequency of
-                        letters. The tool automatically calculates the <em>Chi-Square Value</em> to verify the match:
-                </p>
-                <table>
-                    <tbody>
-                        <tr>
-                            <td>E</td>
-                            <td>A</td>
-                            <td>O</td>
-                            <td>SNR</td>
-                            <td>IL</td>
-                            <td>DTUC</td>
-                            <td>MP</td>
-                            <td>BHQ</td>
-                            <td>YVG&Oacute;&Iacute;</td>
-                            <td>FJZ&Aacute;&Eacute;&Ntilde;X&Uacute;KW&Uuml;</td>
-                        </tr>
-                        <tr>
-                            <td>13%</p>
-                            </td>
-                            <td>12%</p>
-                            </td>
-                            <td>8%</p>
-                            </td>
-                            <td>7%</p>
-                            </td>
-                            <td>6%</p>
-                            </td>
-                            <td>5%</p>
-                            </td>
-                            <td>3%</p>
-                            </td>
-                            <td>2%</p>
-                            </td>
-                            <td>1%</p>
-                            </td>
-                            <td>-</p>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-                <p class="c36">If the encoded string uses both <span class="fq">N</span> and <span
-                        class="fq">&Ntilde;</span>,
-                    it is best to re-encode until you don't get them both to avoid
-                    confusion on the part of the teams. Although it is possible to get an encoding that doesn't use
-                    <span class="fq">&Ntilde;</span> at all, it is perfectly fine to generate a question which
-                    has one. Having both both <span class="fq">N</span> and <span class="fq">&Ntilde;</span>, though,
-                    increases the difficulty of the problem.
-                </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The presence of cognates greatly
-                    reduces the difficulty. It is also expected that a K1 alphabet with an English key should be used.
-                    A K2 alphabet can be used, but it doesn't reduce the difficulty as much. In Division B, only a K1
-                    alphabet can be used. In Division C, you might expect to find one of each.</p>
-                <span class="ht">Points:</span>
-                <p class="in">600-700.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in"> The question should clearly indicate that it
-                    is a Spanish Xenocrypt and provide the source of the phrase (if known). It should also indicate the
-                    use of a K1 (or K2) alphabet with an English keyword. For example:</p>
-                <p class="ex callout small secondary ">Solve this Xenocrypt which is a translation of a quote by
-                    <em>&lt;person&gt;</em>
-                    into
-                    Spanish and has been encoded with a K1 alphabet using an English keyword.
-                </p>
-            </div>
             <div id="Cryptarithm">
                 <h2 class="ol">
                     <div class="quseb">
                         <div class="qusec"></div>
-                    </div>Cryptarithm B{3.e.v}, C{3.e.vi}
+                    </div>Cryptarithm
                 </h2>
                 <p>The Cryptarithm is a cipher that maps each digit 0-9 to a different letter and provides an entire
                     mathematical equation where the digits are substituted with the corresponding letters. Competitors
@@ -1139,7 +1168,7 @@
             <div id="CompleteColumnar">
                 <h2 class="ol">
                     <div class="qusec"></div>
-                    <div class="quseb"></div>Complete Columnar B{3.e.vii}, C{3.e.viii},{3.f.vi}
+                    <div class="quseb"></div>Complete Columnar
                 </h2>
                 <p>The Complete Columnar Cipher is a transposition cipher. Plain text is written across a table with a
                     pre-defined number of columns. The column order is mixed up by providing a
@@ -1223,9 +1252,396 @@
                     setting difficulty for these. Reviewing the work done by the Auto-Solver can also help guide the
                     choice of crib.</p>
             </div>
+            <div id="FractionatedMorse">
+                <h2 class="ol">
+                    <div class="qusec"></div>
+                    <div class="quseb"></div>Fractionated Morse Cryptanalysis
+                </h2>
+                <p>The Fractionated Morse Cipher encodes text by first converting the plain text into morse
+                    code with the space between characters represented by an <span class="fq">&times;</span> and the
+                    space between words represented by two <span class="fq">&times;</span> characters. The resulting
+                    morse code string is divided into groups of three characters called a morslet. The morslet is
+                    made up of combinations of these characters:
+                    (<span class="fq">&#9679;</span>,
+                    <span class="fq">&ndash;</span>,
+                    <span class="fq">&times;</span>). There are 27
+                    possible morselets using combinations of those characters. Each morslet is
+                    assigned to letters using a K1-like replacement table. 26 morselets are
+                    used in the replacement table; (<span class="fq">&times;&times;&times;</span>) is not used.
+                    The table is always the same, and the letters in the keyword (with
+                    duplicates removed) are always the initial letters in the table, with the remaining letters
+                    following alphabetically.
+                    The morslet (sets of morse
+                    characters) are then replaced with the corresponding letter to generate
+                    the final cipher string. Decoding is done by reversing the process. The YouTube video on how to
+                    generate a Fractionated Morse cipher using the Test Generator can be found <a class="ytvideo"
+                        href="https://www.youtube.com/watch?v=13BJiRSIbYg">here</a>.
+                </p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">
+                    The difficulty will depend on how many cipher characters are revealed by the crib. This is
+                    determined
+                    by the length of the crib and where it is placed. The difficulty is also related to the
+                    letters that are chosen for the keyword, although less so. Difficulty
+                    increases when the keyword draws letters spread throughout the alphabet, when it draws
+                    from the end of the alphabet, when the keyword is very long, and when there are duplicate letters in
+                    the keyword.
+                    Another factor for difficulty is how frequently the cipher letters that are revealed by the crib
+                    are used in the cipher.
+                </p>
+                <p class="in1">A crib which provides 10 to 12 mappings of cipher letters to morslets should be adequate
+                    to solve the cipher in a reasonable amount of time. As stated above, the position and length
+                    of the crib determine how many cipher letters are revealed. A shorter crib may reveal
+                    more cipher letters than a longer crib, it all depends on the length of the morse characters
+                    generated
+                    by the plain text. The auto-solver output shows what cipher characters the crib reveals, so trying
+                    different cribs
+                    gives immediate feedback to the test writer. The auto-solver also makes an estimate
+                    of the length of the keyword. How close this estimate is to the actual length of the keyword
+                    will make the problem marginally easier.
+                </p>
+                <p class="in1">Looking at the
+                    auto-solver output should give an idea of how much effort a problem will take to solve. The
+                    auto-solver
+                    iterates through logic and builds upon previous progress--techniques a student would use. Put
+                    another way,
+                    in general, the longer the output from the auto-solver, the more effort it will take a student to
+                    solve it,
+                    thus a more difficult problem.
+                </p>
+
+                <span class="ht">Points:</span>
+                <p class="in">350-420. This can be adjusted using the factors for difficulty above. The 'Suggest Points'
+                    button uses these considerations to determine a score.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in">The question should be around 40 characters. Note that the encoded text revealed by the
+                    11 characters of the crib has a length of 13 characters, but only 9 are unique.</p>
+                <p class="ex callout small secondary">
+                    Someone passed you a piece of paper with this Fractionated Morse encoded phrase of a quote. You are
+                    told that the quote has <span class="fq">EDSOMEMAGIC</span> in it corresponding to the encoded text
+                    <span class="fq">N G S N L L E L B J S V H</span>,
+                    meaning <span class="fq">B = &#9679;–×; E = &#9679;××; G = &#9679;&#9679;×; H = –&#9679;×;
+                        J = ––&#9679;; L = ––×; N = &#9679;×–; S = ×&#9679;&#9679;; V = ×–&#9679;</span>. What does it
+                    say?
+                </p>
+            </div>
+
+            <div id="Porta_Decrypt">
+                <h2 class="ol">
+                    <div class="qusecs"></div>
+                    <div class="qusebs"></div>Porta Cryptanalysis
+                </h2>
+                <p>There can be one of these on a State/National test. There are no restrictions on the phrase,
+                    although try to avoid a phrase with a lot of a's in it. I.e.<span class="fq">An amazing
+                        aardvark allows all answers</span> would be a poor choice because the letter <span
+                        class="fq">A</span> is
+                    trivial to decode. As this question is nominally worth four points per letter, a 50 letter phrase is
+                    ideal. </p>
+                <p>Additionally there needs to be a <span class="ctl">Key</span> to encode it
+                    with. It should be 5 or 6 characters with no repeating letters and avoid the letter <em>a</em> as
+                    it causes a letter to map to itself. By setting the <span class="ctl">Block Size</span> to the same
+                    as the length of the Key,
+                    the problem is much easier than with the default <span class="ctl">Block Size</span> of 0
+                    that keeps the original spacing. Setting the <span class="ctl">Block Size</span> to a
+                    size other than the length of the <span class="ctl">Key</span> increases the
+                    difficulty somewhat. </p>
+                <p>For the decoding clue, pick a word in the phrase which is at least 5 characters
+                    long, carefully count to determine the position in the encoded phrase as well as the encoded
+                    character.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The length of the phrase is the major factor affecting the difficulty, as is the choice of
+                    crib: it will be easier if the letters in the crib fall aligned with the pattern of the key. Unlike
+                    many other keyword ciphers, this one actually becomes marginally easier if there are duplicate
+                    letters in the key, as it reduces the number of rows and columns that competitors have to consult.
+                </p>
+                <span class="ht">Points:</span>
+                <p class="in">200-250. If the <span class="ctl">Block Size</span> is
+                    0, add 25 points. If the <span class="ctl">Block Size</span> is non-zero and
+                    different from the <span class="ctl">Key</span> length, add 50 points.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should indicate that the
+                    Porta Cipher is being used, the length of the Key and
+                    the plain text corresponding to some part of the phrase. It is generally nice to give the origin of
+                    the phrase if it is known. For example:</p>
+                <p class="ex callout small secondary "><em>&lt;person&gt;</em> once said this about
+                    <em>&lt;topic&gt;</em>. It
+                    has
+                    been
+                    encoded
+                    using the
+                    Porta cipher using a very common five letter word. You have been told that the 17th
+                    through
+                    the 22nd letters in the code (<span class="fq">YMNCHU</span>) actually is the word <span
+                        class="fq">REASON</span>.
+                    What does the message decode to?
+                </p>
+            </div>
+            <div id="PigPen">
+                <h2 class="ol">
+                    <div class="qusea"></div>PigPen Cipher
+                </h2>
+                <p>The PigPen/Masonic Cipher is one of the easiest Ciphers for students to decode because the alphabet
+                    is fixed. The letter <b>E</b> will always be represented by a square. There can be a couple of
+                    PigPen Cipher questions on a test. There is an accompanying YouTube video for creating a PigPen
+                    cipher that can be found <a class="ytvideo"
+                        href="https://www.youtube.com/watch?v=gXWzM0g6kXI">here</a>.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The only factor for difficulty with this
+                    question is in the number of characters in the phrase. The choice of letters/words/word length has
+                    no impact on the difficulty. In general the question should be approximately 40-50 characters.</p>
+                <span class="ht">Points:</span>
+                <p class="in">A PigPen Cipher <span class="ctl">Decode</span> should
+                    be worth 60-80 points (approximately 1 point per character in the <span class="ctl">Plain
+                        Text</span> plus 1.5 points for each unique character).
+                </p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should clearly indicate that
+                    cipher has been encoded using the PigPen Cipher as well as the origin of the phrase or quote. It
+                    should not include a hint. For example:</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded with the PigPen Cipher.</p>
+            </div>
+            <div id="KnightsTemplar">
+                <h2 class="ol">
+                    <div class="qusea"></div>Knights Templar Cipher
+                </h2>
+                <p>The Knights Templar Cipher is similar to the PigPen/Masonic Cipher and is generally easy for students
+                    to decode because the alphabet
+                    is fixed. The letter <b>N</b> will always be represented by an X. There can be a couple of
+                    Knights Templar Cipher questions on a test. </p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The only factor for difficulty with this
+                    question is in the number of characters in the phrase. The choice of letters/words/word length has
+                    no impact on the difficulty. In general the question should be approximately 40-50 characters.</p>
+                <span class="ht">Points:</span>
+                <p class="in">A Knights Templar Cipher <span class="ctl">Decode</span> should
+                    be worth 60-80 points (approximately 1 point per character in the <span class="ctl">Plain
+                        Text</span> plus 1.5 points for each unique character).
+                </p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should clearly indicate that
+                    cipher has been encoded using the Knights Templar Cipher as well as the origin of the phrase or
+                    quote. It
+                    should not include a hint. For example:</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded with the Knights Templar Cipher.</p>
+            </div>
+            <div id="StandardGalacticAlphabet">
+                <h2 class="ol">
+                    <div class="qusea"></div>Standard Galactic Alphabet Cipher
+                </h2>
+                <p>The Standard Galactic Alphabet is another type of simple cipher with a fixed alphabet. Each letter in
+                    the alphabet corresponds with a symbol, and is represented by the same symbol each time it appears.
+                    The letter <b>Y</b> will always be represented by a symbol that looks like two vertical lines
+                    <b>||</b>.
+                    Additionally, it is worth noting that in its appearance on the resource sheet, the Standard Galactic
+                    Alphabet is not provided in alphabetic order, but instead is represented with a common pangram (a
+                    sentence that includes each letter of the alphabet). Students will need to familiarize themselves
+                    with
+                    the pangram sentence "The quick brown fox jumps over the lazy dog" in order to be able to map the
+                    Standard Galactic symbols with the corresponding plaintext letters. There can be several Standard
+                    Galactic Alphabet questions on a test.
+                </p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The two factors for difficulty with this
+                    question are the number of characters in the phrase, and the number of unique characters that are
+                    used. The choice of letters/words/word length has
+                    no impact on the difficulty. In general the question should be approximately 40-50 characters.</p>
+                <span class="ht">Points:</span>
+                <p class="in">A Standard Galactic Alphabet Cipher <span class="ctl">Decode</span> should
+                    be worth roughly 80 points (approximately 1 point per character in the <span class="ctl">Plain
+                        Text</span> plus 2 points for each unique character).
+                </p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should clearly indicate that
+                    cipher has been encoded using the Standard Galactic Alphabet as well as the origin of the phrase or
+                    quote. It
+                    should not include a hint. For example:</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded with the Standard Galactic Alphabet.</p>
+            </div>
+
+            <div id="TapCode">
+                <h2 class="ol">
+                    <div class="qusea"></div>Tap Code Cipher
+                </h2>
+                <p>The Tap Code is is a simple cipher to decode because the mapping is
+                    is fixed. A single dot followed by a single dot will always stand for the letter <b>a</b>.
+                    What makes it slightly more challenging is that the students need to
+                    memorize the table or just know how to recreate it on the test.
+                    There should be one or two Tap Code Cipher questions on a test. The accompanying instructional
+                    YouTube video can be found <a class="ytvideo"
+                        href="https://www.youtube.com/watch?v=gLvGtFHkppM">here</a>.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The two factors for difficulty with this
+                    question is in the number of characters in the phrase and how far down in the alphabet
+                    the letters are. The further in the alphabet, the more characters that they have to count.</p>
+                <span class="ht">Points:</span>
+                <p class="in">A Tap Code Cipher should be worth 55-75 points. This works out to about 1.5 points per
+                    letter or one point for every 3 or 4 taps generated.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should clearly indicate that
+                    cipher has been encoded using the Tap Code Cipher. It
+                    should not include a hint. For example:</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded with the Tap Code Cipher.</p>
+            </div>
+            <div id="DancingMen">
+                <h2 class="ol">
+                    <div class="qusen"></div>Dancing Men Cipher
+                </h2>
+                <p>The Dancing Men Cipher (also known as the Running Men Cipher) is one of the easiest Ciphers for
+                    students to decode because the alphabet
+                    is fixed. The letter <b>E</b> will always be represented by a person with both arms up in the air
+                    and both legs split. There can be a couple of
+                    Dancing Men Cipher questions on a test. There is a YouTube video showing how to implement a Dancing
+                    Men cipher <a class="ytvideo" href="https://www.youtube.com/watch?v=wf1U6sSxFJg">here</a>.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The only factor for difficulty with this
+                    question is in the number of characters in the phrase. The choice of letters/words/word length has
+                    no impact on the difficulty. In general the question should be approximately 40 characters.</p>
+                <span class="ht">Points:</span>
+                <p class="in">A Dancing Men Cipher <span class="ctl">Decode</span> should
+                    be worth 80 points (approximately 1 point per character in the <span class="ctl">Plain
+                        Text</span> and 2 points for how many of the characters are unique).
+                </p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should clearly indicate that
+                    cipher has been encoded using the Dancing Men Cipher as well as the origin of the phrase or quote.
+                    It
+                    should not include a hint. For example:</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded with the Dancing Men Cipher.</p>
+            </div>
+
+            <div id="Affinedecode">
+                <h2 class="ol">
+                    <div class="qusen"></div>
+                    <span id="Affine"></span>
+                    Affine Cipher decrypt
+                </h2>
+                <p>There should be a single one of these on the test. It should use a phrase about 25
+                    characters long that doesn't have too many occurrences of the letter <span class="fq">A</span> in
+                    it, preferably with as large a variety of letters as possible&hellip; (e.g. <span class="fq">The
+                        quick brown fox jumps over the lazy dog</span> isn't actually bad). </p>
+                <p>Pick a value for <em>a</em> which is coprime with 26
+                    (1,3,5,7,9,11,15,17,19,21,23 or 25). The actual value doesn't matter, but larger ones tend to
+                    be slightly harder. If you are generating tests for multiple regions, pick numbers that are near
+                    each other. I.e. 7, 9 and 11 would be good to have as equivalent <em>a</em> values.</p>
+                <p>Pick a value for <em>b</em> between 1 and 25 inclusive.
+                    Unlike <em>a</em> where the larger values become slightly
+                    harder, the value of <em>b</em> can truly be any number
+                    and be the same level of difficulty. There is an accompanying YouTube video demonstrating how to
+                    create an Affine Cipher Decrypt problem in the YouTube video linked <a class="ytvideo"
+                        href="https://www.youtube.com/watch?v=_eV6ruYNexY">here</a>.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">There is very little variability in the
+                    difficulty other than the length of the string. Larger values of <em>a</em> are
+                    only slightly harder while the value of <em>b</em> has no real
+                    impact on the difficulty.</p>
+                <span class="ht">Points:</span>
+                <p class="in">100.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in">The question should state to use the Affine Cipher and
+                    give the values of <em>a</em> and
+                    <em>b</em> for them to use (note that <em>a</em> and
+                    <em>b</em> are italicized).
+                    For example:
+                </p>
+                <p class="ex callout small secondary ">Decrypt the following cipher text which was encoded using
+                    the Affine Cipher with a=<em>5</em> and b=<em>9</em>.</p>
+            </div>
+            <div id="Affinecrypt">
+                <h2 class="ol">
+                    <div class="qusen"></div>Affine Cryptanalysis
+                </h2>
+                <p>There should be a single one of these on the State/National test. It should use a
+                    phrase about 25 characters long that doesn't have too many occurrences of the letter <em>a</em> in
+                    it, preferably with as large a variety of letters as possible.
+                    (e.g. <span class="fq">The quick brown fox jumps over the lazy dog</span> isn't
+                    actually bad).</p>
+                <p>Pick a value for <em>a</em> which is coprime with 26
+                    (1,3,5,7,9,11,15,17,19,21,23 or 25). The actual value doesn't matter, but larger ones tend to
+                    be slightly harder. If you are generating tests for multiple regions, pick numbers that are near
+                    each other. I.e. 7, 9 and 11 would be good to have as equivalent <em>a</em> values.</p>
+                <p>Pick a value for <em>b</em> between 1 and 25 inclusive.
+                    Unlike <em>a</em> where the larger values become slightly
+                    harder, the value of <em>b</em> can truly be any number
+                    and be the same level of difficulty. There is a YouTube video demonstrating the creation of an
+                    Affine Cryptanalysis cipher <a class="ytvideo"
+                        href="https://www.youtube.com/watch?v=oVoTAXcwO3E">here</a>.</p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">There is very little variability in the
+                    difficulty other than the length of the string. Larger values of <em>a</em> are
+                    only slightly harder while the value of <em>b</em> has no real impact on
+                    the difficulty. Picking the two mapping letters so that they are toward the end of the
+                    alphabet also
+                    increase the difficulty. Having phrases which use the letters <span class="fq">G</span>,
+                    <span class="fq">W</span>, <span class="fq">Y</span>, <span class="fq">B</span>,
+                    <span class="fq">V</span>, <span class="fq">K</span>, <span class="fq">X</span>,
+                    <span class="fq">J</span>, <span class="fq">Q</span>, and <span class="fq">Z</span> increase
+                    the difficulty slightly.
+                </p>
+                <span class="ht">Points:</span>
+                <p class="in">140-240. A good rule of thumb is 6 points per
+                    character plus 6 points for each of the letters <span class="fq">G</span>, <span
+                        class="fq">W</span>,
+                    <span class="fq">Y</span>, <span class="fq">B</span>, <span class="fq">V</span>,
+                    <span class="fq">K</span>, <span class="fq">X</span>, <span class="fq">J</span>,
+                    <span class="fq">Q</span>, and <span class="fq">Z</span> that are used.
+                </p>
+                <span class="ht">Question Text:</span>
+                <p class="in">The question should state to use the Affine Cipher and
+                    the indication of what two letters map to. It should not give the values of <em>a</em> or
+                    <em>b</em>. For example:
+                </p>
+                <p class="ex callout small secondary ">A message from <em>&lt;person&gt;</em> encrypted with the Affine
+                    Cipher using an alphabet of 26 characters has been received. You have been told that the first two
+                    letters are <span class="ctl">TH</span>. With that knowledge, what does this message say?</p>
+            </div>
+
+            <div id="Affineencode">
+                <h2 class="ol">
+                    <div class="qusen"></div>
+                    Affine Cipher encrypt
+            </div>
+            </h2>
+            <p>There should be at most a single one of these on the test. It should use a phrase about 25
+                characters long that doesn't have too many occurrences of the letter <span class="fq">A</span> in
+                it, preferably with as large a variety of letters as possible&hellip; (e.g. <span class="fq">The
+                    quick brown fox jumps over the lazy dog</span> isn't actually bad). </p>
+            <p>Pick a value for <em>a</em> which is coprime with 26
+                (1,3,5,7,9,11,15,17,19,21,23 or 25). The actual value doesn't matter, but larger ones tend to
+                be slightly harder. If you are generating tests for multiple regions, pick numbers that are near
+                each other. I.e. 7, 9 and 11 would be good to have as equivalent <em>a</em> values.</p>
+            <p>Pick a value for <em>b</em> between 1 and 25 inclusive.
+                Unlike <em>a</em> where the larger values become slightly
+                harder, the value of <em>b</em> can truly be any number
+                and be the same level of difficulty.</p>
+            <span class="ht">Setting Difficulty:</span>
+            <p class="in">There is very little variability in the
+                difficulty other than the length of the string. Larger values of <em>a</em> are
+                only slightly harder while the value of <em>b</em> has no real
+                impact on the difficulty.</p>
+            <span class="ht">Points:</span>
+            <p class="in">100.</p>
+            <span class="ht">Question Text:</span>
+            <p class="in">The question should state to use the Affine Cipher and
+                include the phrase to encode along with the values of <em>a</em> and
+                <em>b</em> for them to use (note that <em>a</em> and
+                <em>b</em> are italicized).
+                For example:
+            </p>
+            <p class="ex callout small secondary ">Encrypt the common phrase <span class="fq">The quick brown fox
+                    jumps over
+                    the
+                    lazy dog</span> using
+                the Affine Cipher with a=5 and b=9.</p>
+            </div>
             <div id="Hill_Matrix">
                 <h2 class="ol">
-                    Decryption matrix for Hill Cipher {not currently used}
+                    <div class="qusen"></div>
+                    Decryption matrix for Hill Cipher
                 </h2>
                 <p>For Regional and Invitational competitions, only the <span class="ctl">Compute Decryption</span>
                     option
@@ -1329,9 +1745,87 @@
                     and for any other number of odd letters, it is simply impossible.
                 </p>
             </div>
+            <div id="Hill_Encrypt">
+                <h2 class="ol">
+                    <div class="qusen"></div>Hill Cipher Encrypt
+                </h2>
+                <p>Pick a phrase to encode. As a rule of thumb for a 2x2 matrix, every pair of letters is
+                    worth 16 points. Ideally you want an odd length string to force them to use a padding Z.
+                    For a 3x3 matrix, every group of three letters is worth 21
+                    points. It is important to pick a phrase which is not a multiple of 3 characters long so that
+                    they must add the appropriate number of padding characters.</p>
+                <p>Pick an encoding key. For a 2x2 it is 4 characters long and for a 3x3 it is 9 characters
+                    long. This is probably the hardest part to making the test as the matrix has to be invertible (<a
+                        href="https://en.wikipedia.org/wiki/Invertible_matrix">https://en.wikipedia.org/wiki/Invertible_matrix</a>).
+                    Fortunately, the tool will tell you if it is not invertible. There is also a list of
+                    known
+                    valid keys at<a href="https://toebes.com/codebusters/HillKeys.html">
+                        https://toebes.com/codebusters/HillKeys.html</a> for
+                    both the 2x2 and 3x3 encodings. In general, it is more likely to be invertible if you use
+                    the letters
+                    <span class="fq">B</span>, <span class="fq">D</span>, <span class="fq">F</span>,
+                    <span class="fq">H</span>, <span class="fq">L</span>, <span class="fq">N</span>,
+                    <span class="fq">R</span>, <span class="fq">T</span>, <span class="fq">X</span> and
+                    <span class="fq">Z</span>. as they are odd and non-prime, but you can mix in some other
+                    letters. Just make sure that the keyword is not an inappropriate phrase.
+                    A total nonsense phrase is perfectly acceptable, but it helps the style of the test if it looks like
+                    a word. There is a YouTube video on generating a Hill Cipher using the tool which can be found <a
+                        class="ytvideo" href="https://www.youtube.com/watch?v=BihtG3Pm8fQ">here</a>.
+                </p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">Encrypt is harder than Decrypt and
+                    3x3 is harder than 2x2. The other factor is the number of characters for them to encode.</p>
+                <span class="ht">Points:</span>
+                <p class="in">160-250. About 16 points per group of 2 for a 2x2, 21 points per group of 3 for a 3x3.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in"> The question should indicate whether they are
+                    to <span class="ctl">Encode</span> or <span class="ctl">Decode</span> using the Hill Cipher with a
+                    26
+                    character
+                    alphabet along with the Key. For
+                    example:</p>
+                <p class="ex callout small secondary ">Using a key of <span class="fq">CARNIVALS</span> encode the
+                    string <span class="ctl">ASTROBIOLOGIST</span> using
+                    the Hill Cipher with a 26-character
+                    alphabet.</p>
+                <p class="ex callout small secondary ">Decode the following quote by <em>&lt;person&gt;</em> which was
+                    encoded
+                    as a 2x2 Hill Cipher using a keyword of <span class="ctl">LOST</span>.
+                </p>
+            </div>
+
+
+            <div id="RailFence">
+                <h2 class="ol">
+                    <div class="qusen"></div>
+                    Rail Fence Cipher
+                </h2>
+                <p>The rail fence cipher encodes messages by 'zig-zagging' the letters along 2 to 6 'rails'. The cipher
+                    can
+                    be decoded by brute force; trial and error; or procedurally by applying some simple math and
+                    understanding spacing of characters in the rail patterns.
+                </p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The difficulty gets slightly higher with more rails because it requires more diligence
+                    when solving. It becomes slightly more difficult when there is an offset, and significantly moreso
+                    when the offset is unknown because of the additional time investment required for trial and error.
+                </p>
+                <span class="ht">Points:</span>
+                <p class="in">100-150. A rule of thumb: 2 rails = 100; 3 rails = 110; 4 rails = 120; 5 rails = 130;
+                    6 rails = 140 points. 150 points for when only the range of rails is given.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in">The question should be around 75 characters.</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded with the rail fence cipher. The message was encoded with <em>&lt;rail
+                        count&gt;</em> rails.
+                </p>
+            </div>
+
             <div id="Morbitdecode">
                 <h2 class="ol">
-                    Morbit Cipher Decode {not currently used}</h2>
+                    <div class="qusen"></div>
+                    Morbit Cipher Decode
+                </h2>
                 <p>The Morbit Cipher encodes text by first converting the plain text into morse
                     code with the space between characters represented by an
                     <span class="fq">&times;</span> and the space between
@@ -1366,9 +1860,52 @@
                         4=&#9679;&ndash;, 6=&#9679;&times;,
                         9=&ndash;&#9679;, 1=&ndash;&ndash;, and 7=&ndash;&times;</span>. </p>
             </div>
+            <div id="Morbitcrypt">
+                <h2 class="ol">
+                    <div class="qusen"></div>
+                    Morbit Cryptanalysis
+                </h2>
+                <p>The Morbit Cipher encodes text by first converting the plain text into morse
+                    code with the space between characters represented by an <span class="fq">&times;</span> and the
+                    space
+                    between
+                    words represented by two <span class="fq">&times;</span> characters. The resulting morse code is
+                    then
+                    broken into pairs of characters (adding an <span class="fq">&times;</span> at the end if necessary).
+                    The numbers 1-9 are randomly assigned to the unique pairs of characters
+                    (<span class="fq">&#9679;&#9679;</span>,
+                    <span class="fq">&#9679;&ndash;</span>,
+                    <span class="fq">&#9679;&times;</span>,
+                    <span class="fq">&ndash;&#9679;</span>,
+                    <span class="fq">&ndash;&ndash;</span>,
+                    <span class="fq">&ndash;&times;</span>,
+                    <span class="fq">&times;&#9679;</span>,
+                    <span class="fq">&times;&ndash;</span>,
+                    <span class="fq">&times;&times;</span>). The pairs of morse
+                    characters are then replaced with the corresponding number to generate
+                    the final cipher string. Decoding is done by reversing the process.
+                </p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">The difficulty is driven by the number of letters and the
+                    variety of morse code combined with which letters are chosen. Looking
+                    at the generated solving guide can help guide the question writing. Not giving them
+                    Hint Digits which exposes the digit corresponding to
+                    <span class="fq">&times;&times;</span>
+                    increases the difficulty.
+                </p>
+                <span class="ht">Points:</span>
+                <p class="in">150-200.</p>
+                <span class="ht">Question Text:</span>
+                <p class="in">The question should be around 40 characters.</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded using the Morbit Cipher. You are told that the first
+                    four letters are <span class="fq">SOME</span>.</p>
+            </div>
+
             <div id="Polluxdecode">
                 <h2 class="ol">
-                    Pollux Cipher Decode {not currently used}
+                    <div class="qusen"></div>
+                    Pollux Cipher Decode
                 </h2>
                 <p>The Pollux Cipher encodes text by first converting the plain text into morse
                     code with the space between characters represented by an <span class="fq">&times;</span> and the
@@ -1403,123 +1940,52 @@
                     has been encoded using the Pollux Cipher. You are told that <span class="fq">2,3=&#9679;,
                         4,7=&ndash;, 9,1=&times;</span>. </p>
             </div>
-            <div id="FractionatedMorse">
+            <div id="Polluxcrypt">
                 <h2 class="ol">
-                    <div class="qusec"></div>
-                    <div class="quseb"></div>Fractionated Morse Cipher Cryptanalysis B{3.e.iv}, C{3.e.v}
+                    <div class="qusen"></div>
+                    Pollux Cryptanalysis
                 </h2>
-                <p>The Fractionated Morse Cipher encodes text by first converting the plain text into morse
+                <p>The Pollux Cipher encodes text by first converting the plain text into morse
                     code with the space between characters represented by an <span class="fq">&times;</span> and the
-                    space between words represented by two <span class="fq">&times;</span> characters. The resulting
-                    morse code string is divided into groups of three characters called a morslet. The morslet is
-                    made up of combinations of these characters:
+                    space
+                    between
+                    words represented by two <span class="fq">&times;</span> characters. The resulting morse code is
+                    then
+                    randomly assigned to digits (0-9) chosen to represent the morse characters:
                     (<span class="fq">&#9679;</span>,
                     <span class="fq">&ndash;</span>,
-                    <span class="fq">&times;</span>). There are 27
-                    possible morselets using combinations of those characters. Each morslet is
-                    assigned to letters using a K1-like replacement table. 26 morselets are
-                    used in the replacement table; (<span class="fq">&times;&times;&times;</span>) is not used.
-                    The table is always the same, and the letters in the keyword (with
-                    duplicates removed) are always the initial letters in the table, with the remaining letters
-                    following alphabetically.
-                    The morslet (sets of morse
-                    characters) are then replaced with the corresponding letter to generate
-                    the final cipher string. Decoding is done by reversing the process. The YouTube video on how to
-                    generate a Fractionated Morse cipher using the Test Generator can be found <a class="ytvideo"
-                        href="https://www.youtube.com/watch?v=13BJiRSIbYg">here</a>.
+                    <span class="fq">&times;</span>)
+                    Each morse
+                    character is then replaced with the corresponding number to generate
+                    the final cipher string. Decoding is done by reversing the process.
+                    Note that because one or more digits may represent a morse character piece,
+                    the mapping can be somewhat random.
                 </p>
                 <span class="ht">Setting Difficulty:</span>
-                <p class="in">
-                    The difficulty will depend on how many cipher characters are revealed by the crib. This is
-                    determined
-                    by the length of the crib and where it is placed. The difficulty is also related to the
-                    letters that are chosen for the keyword, although less so. Difficulty
-                    increases when the keyword draws letters spread throughout the alphabet, when it draws
-                    from the end of the alphabet, when the keyword is very long, and when there are duplicate letters in
-                    the keyword.
-                    Another factor for difficulty is how frequently the cipher letters that are revealed by the crib
-                    are used in the cipher.
+                <p class="in">The difficulty is driven by the number of letters and the
+                    variety of morse code combined with which letters are chosen. Looking
+                    at the generated solving guide can help guide the question writing. Not giving them
+                    Hint Digits which exposes all the digits corresponding to
+                    <span class="fq">&times;</span>
+                    increases the difficulty. Assigning more characters for one morse digit,
+                    thereby reducing another, also increases the difficulty.
                 </p>
-                <p class="in1">A crib which provides 10 to 12 mappings of cipher letters to morslets should be adequate
-                    to solve the cipher in a reasonable amount of time. As stated above, the position and length
-                    of the crib determine how many cipher letters are revealed. A shorter crib may reveal
-                    more cipher letters than a longer crib, it all depends on the length of the morse characters
-                    generated
-                    by the plain text. The auto-solver output shows what cipher characters the crib reveals, so trying
-                    different cribs
-                    gives immediate feedback to the test writer. The auto-solver also makes an estimate
-                    of the length of the keyword. How close this estimate is to the actual length of the keyword
-                    will make the problem marginally easier.
-                </p>
-                <p class="in1">Looking at the
-                    auto-solver output should give an idea of how much effort a problem will take to solve. The
-                    auto-solver
-                    iterates through logic and builds upon previous progress--techniques a student would use. Put
-                    another way,
-                    in general, the longer the output from the auto-solver, the more effort it will take a student to
-                    solve it,
-                    thus a more difficult problem.
-                </p>
-
                 <span class="ht">Points:</span>
-                <p class="in">350-400. This can be adjusted using the factors for difficulty above. The 'Suggest Points'
-                    button uses these considerations to determine a score.</p>
+                <p class="in">150-200.</p>
                 <span class="ht">Question Text:</span>
-                <p class="in">The question should be around 40 characters. Note that the encoded text revealed by the
-                    11 characters of the crib has a length of 13 characters, but only 9 are unique.</p>
-                <p class="ex callout small secondary">
-                    Someone passed you a piece of paper with this Fractionated Morse encoded phrase of a quote. You are
-                    told that the quote has <span class="fq">EDSOMEMAGIC</span> in it corresponding to the encoded text
-                    <span class="fq">N G S N L L E L B J S V H</span>,
-                    meaning <span class="fq">B = &#9679;–×; E = &#9679;××; G = &#9679;&#9679;×; H = –&#9679;×;
-                        J = ––&#9679;; L = ––×; N = &#9679;×–; S = ×&#9679;&#9679;; V = ×–&#9679;</span>. What does it
-                    say?
-                </p>
+                <p class="in">The question should be around 40 characters.</p>
+                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
+                    has been encoded using the Pollux Cipher. You are told that the first
+                    four letters are <span class="fq">SOME</span>.</p>
             </div>
 
-            <div id="RunningKey">
-                <h2 class="ol">
-                    Running Key Cipher {not currently used}
-                </h2>
-                <p>Pick a phrase which is approximately 80 characters long. The actual content has little
-                    impact on the difficulty. By default there are four encoding texts (Gettysburg address, Declaration
-                    of Independence, Constitution of United States of America and MAGNA CARTA (In Latin)) but they can
-                    be
-                    changed by going to <a
-                        href="https://toebes.com/codebusters/EditRunningKeys.html">https://toebes.com/codebusters/EditRunningKeys.html</a>.
-                </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">There is little variability in the difficulty
-                    other than the length. <span class="ctl">Encode</span> is slightly harder than
-                    Decode.</p>
-                <span class="ht">Points:</span>
-                <p class="in">200-250. Approximately 3 points per
-                    letter.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in">The question should indicate that the Running Key Cipher
-                    is being used and whether they are to <span class="ctl">Encode</span> or Decode.
-                    If they are to Encode,
-                    it should indicate which encoding text to use. For example:</p>
-                <p class="ex callout small secondary ">The following quote from <em>&lt;person&gt;</em> has been encoded
-                    using a
-                    running key
-                    cipher
-                    against a famous document. What does it say?</p>
-                <p class="ex callout small secondary ">Encode what <em>&lt;person&gt;</em> said about
-                    <em>&lt;topic&gt;</em>
-                    using
-                    a running
-                    key
-                    cipher
-                    against the MAGNA CARTA.
-                </p>
-            </div>
+
             <div id="Vigenere_Decrypt">
                 <h2 class="ol">
-                    Vigen&egrave;re Cipher Decrypt
-                    with a known plaintext {not currently used}
+                    <div class="qusen"></div>
+                    Vigen&egrave;re Cryptanalysis
                 </h2>
-                <p>There can be one of these on a State/National test. There are no restrictions on the phrase,
+                <p>There are no restrictions on the phrase,
                     although try to avoid a phrase with a lot of a's in it. I.e.<span class="fq">An amazing
                         aardvark allows all answers</span> would be a poor choice because the letter <span
                         class="fq">A</span>
@@ -1566,61 +2032,48 @@
                     What does the message decode to?
                 </p>
             </div>
-            <div id="Porta_Decrypt">
+            <div id="RunningKey">
                 <h2 class="ol">
-                    <div class="qusecs"></div>
-                    <div class="qusebs"></div>Porta Cipher Cryptanalysis
-                    with a known plaintext
-                    B,C{3.f.iii}
+                    <div class="qusen"></div>
+                    Running Key Cipher
                 </h2>
-                <p>There can be one of these on a State/National test. There are no restrictions on the phrase,
-                    although try to avoid a phrase with a lot of a's in it. I.e.<span class="fq">An amazing
-                        aardvark allows all answers</span> would be a poor choice because the letter <span
-                        class="fq">A</span> is
-                    trivial to decode. As this question is nominally worth four points per letter, a 50 letter phrase is
-                    ideal. </p>
-                <p>Additionally there needs to be a <span class="ctl">Key</span> to encode it
-                    with. It should be 5 or 6 characters with no repeating letters and avoid the letter <em>a</em> as
-                    it causes a letter to map to itself. By setting the <span class="ctl">Block Size</span> to the same
-                    as the length of the Key,
-                    the problem is much easier than with the default <span class="ctl">Block Size</span> of 0
-                    that keeps the original spacing. Setting the <span class="ctl">Block Size</span> to a
-                    size other than the length of the <span class="ctl">Key</span> increases the
-                    difficulty somewhat. </p>
-                <p>For the decoding clue, pick a word in the phrase which is at least 5 characters
-                    long, carefully count to determine the position in the encoded phrase as well as the encoded
-                    character.</p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The length of the phrase is the major factor affecting the difficulty, as is the choice of
-                    crib: it will be easier if the letters in the crib fall aligned with the pattern of the key. Unlike
-                    many other keyword ciphers, this one actually becomes marginally easier if there are duplicate
-                    letters in the key, as it reduces the number of rows and columns that competitors have to consult.
+                <p>Pick a phrase which is approximately 80 characters long. The actual content has little
+                    impact on the difficulty. By default there are four encoding texts (Gettysburg address, Declaration
+                    of Independence, Constitution of United States of America and MAGNA CARTA (In Latin)) but they can
+                    be
+                    changed by going to <a
+                        href="https://toebes.com/codebusters/EditRunningKeys.html">https://toebes.com/codebusters/EditRunningKeys.html</a>.
                 </p>
+                <span class="ht">Setting Difficulty:</span>
+                <p class="in">There is little variability in the difficulty
+                    other than the length. <span class="ctl">Encode</span> is slightly harder than
+                    Decode.</p>
                 <span class="ht">Points:</span>
-                <p class="in">200-250. If the <span class="ctl">Block Size</span> is
-                    0, add 25 points. If the <span class="ctl">Block Size</span> is non-zero and
-                    different from the <span class="ctl">Key</span> length, add 50 points.</p>
+                <p class="in">200-250. Approximately 3 points per
+                    letter.</p>
                 <span class="ht">Question Text:</span>
-                <p class="in"> The question should indicate that the
-                    Porta Cipher is being used, the length of the Key and
-                    the plain text corresponding to some part of the phrase. It is generally nice to give the origin of
-                    the phrase if it is known. For example:</p>
-                <p class="ex callout small secondary "><em>&lt;person&gt;</em> once said this about
-                    <em>&lt;topic&gt;</em>. It
-                    has
-                    been
-                    encoded
-                    using the
-                    Porta cipher using a very common five letter word. You have been told that the 17th
-                    through
-                    the 22nd letters in the code (<span class="fq">YMNCHU</span>) actually is the word <span
-                        class="fq">REASON</span>.
-                    What does the message decode to?
+                <p class="in">The question should indicate that the Running Key Cipher
+                    is being used and whether they are to <span class="ctl">Encode</span> or Decode.
+                    If they are to Encode,
+                    it should indicate which encoding text to use. For example:</p>
+                <p class="ex callout small secondary ">The following quote from <em>&lt;person&gt;</em> has been encoded
+                    using a
+                    running key
+                    cipher
+                    against a famous document. What does it say?</p>
+                <p class="ex callout small secondary ">Encode what <em>&lt;person&gt;</em> said about
+                    <em>&lt;topic&gt;</em>
+                    using
+                    a running
+                    key
+                    cipher
+                    against the MAGNA CARTA.
                 </p>
             </div>
             <div id="RSA">
                 <h2 class="ol">
-                    RSA Cipher {not currently used}
+                    <div class="qusen"></div>
+                    RSA Cipher
                 </h2>
                 <p>There are several variants of the RSA question. The <span class="ctl">Safe Combo</span> and
                     <span class="ctl">Exchange Keys</span> options test the knowledge of the RSA algorithm by
@@ -1666,340 +2119,10 @@
                     generated, but can be edited. Note that the tool keeps track of all the edits so that if it
                     generates new values, the edits are kept in place.</p>
             </div>
-            <div id="Hill_Encrypt">
-                <h2 class="ol">
-                    <div class="qusec"></div>Hill Cipher Encrypt/Decrypt C{3.e.x},{3.f.iv}
-                </h2>
-                <p>Pick a phrase to encode. As a rule of thumb for a 2x2 matrix, every pair of letters is
-                    worth 16 points. Ideally you want an odd length string to force them to use a padding Z.
-                    For a 3x3 matrix, every group of three letters is worth 21
-                    points. It is important to pick a phrase which is not a multiple of 3 characters long so that
-                    they must add the appropriate number of padding characters.</p>
-                <p>Pick an encoding key. For a 2x2 it is 4 characters long and for a 3x3 it is 9 characters
-                    long. This is probably the hardest part to making the test as the matrix has to be invertible (<a
-                        href="https://en.wikipedia.org/wiki/Invertible_matrix">https://en.wikipedia.org/wiki/Invertible_matrix</a>).
-                    Fortunately, the tool will tell you if it is not invertible. There is also a list of
-                    known
-                    valid keys at<a href="https://toebes.com/codebusters/HillKeys.html">
-                        https://toebes.com/codebusters/HillKeys.html</a> for
-                    both the 2x2 and 3x3 encodings. In general, it is more likely to be invertible if you use
-                    the letters
-                    <span class="fq">B</span>, <span class="fq">D</span>, <span class="fq">F</span>,
-                    <span class="fq">H</span>, <span class="fq">L</span>, <span class="fq">N</span>,
-                    <span class="fq">R</span>, <span class="fq">T</span>, <span class="fq">X</span> and
-                    <span class="fq">Z</span>. as they are odd and non-prime, but you can mix in some other
-                    letters. Just make sure that the keyword is not an inappropriate phrase.
-                    A total nonsense phrase is perfectly acceptable, but it helps the style of the test if it looks like
-                    a word. There is a YouTube video on generating a Hill Cipher using the tool which can be found <a
-                        class="ytvideo" href="https://www.youtube.com/watch?v=BihtG3Pm8fQ">here</a>.
-                </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">Encrypt is harder than Decrypt and
-                    3x3 is harder than 2x2. The other factor is the number of characters for them to encode.</p>
-                <span class="ht">Points:</span>
-                <p class="in">160-250. About 16 points per group of 2 for a 2x2, 21 points per group of 3 for a 3x3.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in"> The question should indicate whether they are
-                    to <span class="ctl">Encode</span> or <span class="ctl">Decode</span> using the Hill Cipher with a
-                    26
-                    character
-                    alphabet along with the Key. For
-                    example:</p>
-                <p class="ex callout small secondary ">Using a key of <span class="fq">CARNIVALS</span> encode the
-                    string <span class="ctl">ASTROBIOLOGIST</span> using
-                    the Hill Cipher with a 26-character
-                    alphabet.</p>
-                <p class="ex callout small secondary ">Decode the following quote by <em>&lt;person&gt;</em> which was
-                    encoded
-                    as a 2x2 Hill Cipher using a keyword of <span class="ctl">LOST</span>.
-                </p>
-            </div>
-            <div id="Affinecrypt">
-                <h2 class="ol">
-                    <div class="qusebs"></div>Affine Cryptanalysis B{3.f.iv}
-                </h2>
-                <p>There should be a single one of these on the State/National test. It should use a
-                    phrase about 25 characters long that doesn't have too many occurrences of the letter <em>a</em> in
-                    it, preferably with as large a variety of letters as possible.
-                    (e.g. <span class="fq">The quick brown fox jumps over the lazy dog</span> isn't
-                    actually bad).</p>
-                <p>Pick a value for <em>a</em> which is coprime with 26
-                    (1,3,5,7,9,11,15,17,19,21,23 or 25). The actual value doesn't matter, but larger ones tend to
-                    be slightly harder. If you are generating tests for multiple regions, pick numbers that are near
-                    each other. I.e. 7, 9 and 11 would be good to have as equivalent <em>a</em> values.</p>
-                <p>Pick a value for <em>b</em> between 1 and 25 inclusive.
-                    Unlike <em>a</em> where the larger values become slightly
-                    harder, the value of <em>b</em> can truly be any number
-                    and be the same level of difficulty. There is a YouTube video demonstrating the creation of an
-                    Affine Cryptanalysis cipher <a class="ytvideo"
-                        href="https://www.youtube.com/watch?v=oVoTAXcwO3E">here</a>.</p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">There is very little variability in the
-                    difficulty other than the length of the string. Larger values of <em>a</em> are
-                    only slightly harder while the value of <em>b</em> has no real impact on
-                    the difficulty. Picking the two mapping letters so that they are toward the end of the
-                    alphabet also
-                    increase the difficulty. Having phrases which use the letters <span class="fq">G</span>,
-                    <span class="fq">W</span>, <span class="fq">Y</span>, <span class="fq">B</span>,
-                    <span class="fq">V</span>, <span class="fq">K</span>, <span class="fq">X</span>,
-                    <span class="fq">J</span>, <span class="fq">Q</span>, and <span class="fq">Z</span> increase
-                    the difficulty slightly.
-                </p>
-                <span class="ht">Points:</span>
-                <p class="in">140-240. A good rule of thumb is 6 points per
-                    character plus 6 points for each of the letters <span class="fq">G</span>, <span
-                        class="fq">W</span>,
-                    <span class="fq">Y</span>, <span class="fq">B</span>, <span class="fq">V</span>,
-                    <span class="fq">K</span>, <span class="fq">X</span>, <span class="fq">J</span>,
-                    <span class="fq">Q</span>, and <span class="fq">Z</span> that are used.
-                </p>
-                <span class="ht">Question Text:</span>
-                <p class="in">The question should state to use the Affine Cipher and
-                    the indication of what two letters map to. It should not give the values of <em>a</em> or
-                    <em>b</em>. For example:
-                </p>
-                <p class="ex callout small secondary ">A message from <em>&lt;person&gt;</em> encrypted with the Affine
-                    Cipher using an alphabet of 26 characters has been received. You have been told that the first two
-                    letters are <span class="ctl">TH</span>. With that knowledge, what does this message say?</p>
-            </div>
-            <div id="DancingMen">
-                <h2 class="ol">
-                    <div class="qusea"></div>Dancing Men Cipher A{9.c.vii}
-                </h2>
-                <p>The Dancing Men Cipher (also known as the Running Men Cipher) is one of the easiest Ciphers for
-                    students to decode because the alphabet
-                    is fixed. The letter <b>E</b> will always be represented by a person with both arms up in the air
-                    and both legs split. There can be a couple of
-                    Dancing Men Cipher questions on a test. There is a YouTube video showing how to implement a Dancing
-                    Men cipher <a class="ytvideo" href="https://www.youtube.com/watch?v=wf1U6sSxFJg">here</a>.</p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The only factor for difficulty with this
-                    question is in the number of characters in the phrase. The choice of letters/words/word length has
-                    no impact on the difficulty. In general the question should be approximately 40 characters.</p>
-                <span class="ht">Points:</span>
-                <p class="in">A Dancing Men Cipher <span class="ctl">Decode</span> should
-                    be worth 80 points (approximately 1 point per character in the <span class="ctl">Plain
-                        Text</span> and 2 points for how many of the characters are unique).
-                </p>
-                <span class="ht">Question Text:</span>
-                <p class="in"> The question should clearly indicate that
-                    cipher has been encoded using the Dancing Men Cipher as well as the origin of the phrase or quote.
-                    It
-                    should not include a hint. For example:</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded with the Dancing Men Cipher.</p>
-            </div>
-            <div id="PigPen">
-                <h2 class="ol">
-                    <div class="qusea"></div>PigPen Cipher A{9.c.v}
-                </h2>
-                <p>The PigPen/Masonic Cipher is one of the easiest Ciphers for students to decode because the alphabet
-                    is fixed. The letter <b>E</b> will always be represented by a square. There can be a couple of
-                    PigPen Cipher questions on a test. There is an accompanying YouTube video for creating a PigPen
-                    cipher that can be found <a class="ytvideo"
-                        href="https://www.youtube.com/watch?v=gXWzM0g6kXI">here</a>.</p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The only factor for difficulty with this
-                    question is in the number of characters in the phrase. The choice of letters/words/word length has
-                    no impact on the difficulty. In general the question should be approximately 40-50 characters.</p>
-                <span class="ht">Points:</span>
-                <p class="in">A PigPen Cipher <span class="ctl">Decode</span> should
-                    be worth 60-80 points (approximately 1 point per character in the <span class="ctl">Plain
-                        Text</span> plus 1.5 points for each unique character).
-                </p>
-                <span class="ht">Question Text:</span>
-                <p class="in"> The question should clearly indicate that
-                    cipher has been encoded using the PigPen Cipher as well as the origin of the phrase or quote. It
-                    should not include a hint. For example:</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded with the PigPen Cipher.</p>
-            </div>
-            <div id="KnightsTemplar">
-                <h2 class="ol">
-                    <div class="qusea"></div>Knights Templar Cipher A{9.c.viii}
-                </h2>
-                <p>The Knights Templar Cipher is similar to the PigPen/Masonic Cipher and is generally easy for students
-                    to decode because the alphabet
-                    is fixed. The letter <b>N</b> will always be represented by an X. There can be a couple of
-                    Knights Templar Cipher questions on a test. </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The only factor for difficulty with this
-                    question is in the number of characters in the phrase. The choice of letters/words/word length has
-                    no impact on the difficulty. In general the question should be approximately 40-50 characters.</p>
-                <span class="ht">Points:</span>
-                <p class="in">A Knights Templar Cipher <span class="ctl">Decode</span> should
-                    be worth 60-80 points (approximately 1 point per character in the <span class="ctl">Plain
-                        Text</span> plus 1.5 points for each unique character).
-                </p>
-                <span class="ht">Question Text:</span>
-                <p class="in"> The question should clearly indicate that
-                    cipher has been encoded using the Knights Templar Cipher as well as the origin of the phrase or
-                    quote. It
-                    should not include a hint. For example:</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded with the Knights Templar Cipher.</p>
-            </div>
-            <div id="StandardGalacticAlphabet">
-                <h2 class="ol">
-                    <div class="qusea"></div>Standard Galactic Alphabet Cipher A{coming soon}
-                </h2>
-                <p>The Standard Galactic Alphabet is another type of simple cipher with a fixed alphabet. Each letter in
-                    the alphabet corresponds with a symbol, and is represented by the same symbol each time it appears.
-                    The letter <b>Y</b> will always be represented by a symbol that looks like two vertical lines
-                    <b>||</b>.
-                    Additionally, it is worth noting that in its appearance on the resource sheet, the Standard Galactic
-                    Alphabet is not provided in alphabetic order, but instead is represented with a common pangram (a
-                    sentence that includes each letter of the alphabet). Students will need to familiarize themselves
-                    with
-                    the pangram sentence "The quick brown fox jumps over the lazy dog" in order to be able to map the
-                    Standard Galactic symbols with the corresponding plaintext letters. There can be several Standard
-                    Galactic Alphabet questions on a test.
-                </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The two factors for difficulty with this
-                    question are the number of characters in the phrase, and the number of unique characters that are
-                    used. The choice of letters/words/word length has
-                    no impact on the difficulty. In general the question should be approximately 40-50 characters.</p>
-                <span class="ht">Points:</span>
-                <p class="in">A Standard Galactic Alphabet Cipher <span class="ctl">Decode</span> should
-                    be worth roughly 80 points (approximately 1 point per character in the <span class="ctl">Plain
-                        Text</span> plus 2 points for each unique character).
-                </p>
-                <span class="ht">Question Text:</span>
-                <p class="in"> The question should clearly indicate that
-                    cipher has been encoded using the Standard Galactic Alphabet as well as the origin of the phrase or
-                    quote. It
-                    should not include a hint. For example:</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded with the Standard Galactic Alphabet.</p>
-            </div>
 
-            <div id="TapCode">
-                <h2 class="ol">
-                    <div class="qusea"></div>Tap Code Cipher A{9.c.vi}
-                </h2>
-                <p>The Tap Code is is a simple cipher to decode because the mapping is
-                    is fixed. A single dot followed by a single dot will always stand for the letter <b>a</b>.
-                    What makes it slightly more challenging is that the students need to
-                    memorize the table or just know how to recreate it on the test.
-                    There should be one or two Tap Code Cipher questions on a test. The accompanying instructional
-                    YouTube video can be found <a class="ytvideo"
-                        href="https://www.youtube.com/watch?v=gLvGtFHkppM">here</a>.</p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The two factors for difficulty with this
-                    question is in the number of characters in the phrase and how far down in the alphabet
-                    the letters are. The further in the alphabet, the more characters that they have to count.</p>
-                <span class="ht">Points:</span>
-                <p class="in">A Tap Code Cipher should be worth 55-75 points. This works out to about 1.5 points per
-                    letter or one point for every 3 or 4 taps generated.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in"> The question should clearly indicate that
-                    cipher has been encoded using the Tap Code Cipher. It
-                    should not include a hint. For example:</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded with the Tap Code Cipher.</p>
-            </div>
-            <div id="RailFence">
-                <h2 class="ol">
-                    Rail Fence Cipher {not currently used}
-                </h2>
-                <p>The rail fence cipher encodes messages by 'zig-zagging' the letters along 2 to 6 'rails'. The cipher
-                    can
-                    be decoded by brute force; trial and error; or procedurally by applying some simple math and
-                    understanding spacing of characters in the rail patterns.
-                </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The difficulty gets slightly higher with more rails because it requires more diligence
-                    when solving. It becomes slightly more difficult when there is an offset, and significantly moreso
-                    when the offset is unknown because of the additional time investment required for trial and error.
-                </p>
-                <span class="ht">Points:</span>
-                <p class="in">100-150. A rule of thumb: 2 rails = 100; 3 rails = 110; 4 rails = 120; 5 rails = 130;
-                    6 rails = 140 points. 150 points for when only the range of rails is given.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in">The question should be around 75 characters.</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded with the rail fence cipher. The message was encoded with <em>&lt;rail
-                        count&gt;</em> rails.
-                </p>
-            </div>
-            <div id="Morbitcrypt">
-                <h2 class="ol">
-                    Morbit Cipher Cryptanalysis {not currently used}
-                </h2>
-                <p>The Morbit Cipher encodes text by first converting the plain text into morse
-                    code with the space between characters represented by an <span class="fq">&times;</span> and the
-                    space
-                    between
-                    words represented by two <span class="fq">&times;</span> characters. The resulting morse code is
-                    then
-                    broken into pairs of characters (adding an <span class="fq">&times;</span> at the end if necessary).
-                    The numbers 1-9 are randomly assigned to the unique pairs of characters
-                    (<span class="fq">&#9679;&#9679;</span>,
-                    <span class="fq">&#9679;&ndash;</span>,
-                    <span class="fq">&#9679;&times;</span>,
-                    <span class="fq">&ndash;&#9679;</span>,
-                    <span class="fq">&ndash;&ndash;</span>,
-                    <span class="fq">&ndash;&times;</span>,
-                    <span class="fq">&times;&#9679;</span>,
-                    <span class="fq">&times;&ndash;</span>,
-                    <span class="fq">&times;&times;</span>). The pairs of morse
-                    characters are then replaced with the corresponding number to generate
-                    the final cipher string. Decoding is done by reversing the process.
-                </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The difficulty is driven by the number of letters and the
-                    variety of morse code combined with which letters are chosen. Looking
-                    at the generated solving guide can help guide the question writing. Not giving them
-                    Hint Digits which exposes the digit corresponding to
-                    <span class="fq">&times;&times;</span>
-                    increases the difficulty.
-                </p>
-                <span class="ht">Points:</span>
-                <p class="in">150-200.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in">The question should be around 40 characters.</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded using the Morbit Cipher. You are told that the first
-                    four letters are <span class="fq">SOME</span>.</p>
-            </div>
-            <div id="Polluxcrypt">
-                <h2 class="ol">
-                    Pollux Cipher Cryptanalysis {not currently used}
-                </h2>
-                <p>The Pollux Cipher encodes text by first converting the plain text into morse
-                    code with the space between characters represented by an <span class="fq">&times;</span> and the
-                    space
-                    between
-                    words represented by two <span class="fq">&times;</span> characters. The resulting morse code is
-                    then
-                    randomly assigned to digits (0-9) chosen to represent the morse characters:
-                    (<span class="fq">&#9679;</span>,
-                    <span class="fq">&ndash;</span>,
-                    <span class="fq">&times;</span>)
-                    Each morse
-                    character is then replaced with the corresponding number to generate
-                    the final cipher string. Decoding is done by reversing the process.
-                    Note that because one or more digits may represent a morse character piece,
-                    the mapping can be somewhat random.
-                </p>
-                <span class="ht">Setting Difficulty:</span>
-                <p class="in">The difficulty is driven by the number of letters and the
-                    variety of morse code combined with which letters are chosen. Looking
-                    at the generated solving guide can help guide the question writing. Not giving them
-                    Hint Digits which exposes all the digits corresponding to
-                    <span class="fq">&times;</span>
-                    increases the difficulty. Assigning more characters for one morse digit,
-                    thereby reducing another, also increases the difficulty.
-                </p>
-                <span class="ht">Points:</span>
-                <p class="in">150-200.</p>
-                <span class="ht">Question Text:</span>
-                <p class="in">The question should be around 40 characters.</p>
-                <p class="ex callout small secondary ">Solve this quote from <em>&lt;person&gt;</em> which
-                    has been encoded using the Pollux Cipher. You are told that the first
-                    four letters are <span class="fq">SOME</span>.</p>
-            </div>
+
+
+
 </body>
 
 </html>


### PR DESCRIPTION
- First pass at the Homophonic cipher.
- Ciphers rearranged in an order that makes more sense.
- All headings changed to h2.
- Introduces the qusen tag for ciphers that are not used.
- The rule number notations have been removed as they already exist in the "Summary of Ciphers" table.